### PR TITLE
fix a bug in headless case

### DIFF
--- a/mdpd/utils.py
+++ b/mdpd/utils.py
@@ -56,21 +56,18 @@ def from_md(table: str, header=None):
     Returns:
         pd.DataFrame
     """
-    exist_header = header is not None
     rows = []
     for line in table.split("\n"):
         extracted, is_header = _extract_line(line.strip(), len(rows) == 1)
         if is_header:
-            if header is not None:
-                continue
-            exist_header = True
+            if header is None:
+                header = rows[0]
+            rows.pop(0)
+            continue
 
         if extracted == []:
             continue
 
         rows.append(extracted)
 
-    if exist_header:
-        columns = rows[0] if header is None else header
-        return pd.DataFrame(rows[1:], columns=columns)
-    return pd.DataFrame(rows)
+    return pd.DataFrame(rows, columns=header)

--- a/mdpd/version.py
+++ b/mdpd/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.2.0"
+VERSION = "0.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mdpd"
-version = "0.2.0"
+version = "0.2.1"
 description = "a simpler tool for convert markdown table to pandas"
 authors = ["kyoto7250 <50972773+kyoto7250@users.noreply.github.com>"]
 readme = "README.md"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -154,6 +154,15 @@ class TestUtils(unittest.TestCase):
             .all()
         )
 
+        df = utils.from_md(
+            """
+            | Header    | Title       |
+            | Paragraph | Text        |
+            """,
+            header=["Syntax", "Description"],
+        )
+        assert (df == pd.read_csv("tests/fixtures/simple_pattern.csv")).all().all()
+
     def test_with_header_from_md(self):
         df = utils.from_md(
             """


### PR DESCRIPTION
## reproduction case
```python
df =mdpd.from_md("""
| 1          | 15    |
| 2          | 11    |
| 3          | 11    |
| 4          | 20    |
""", header=["id", "score"])

print(df)
#   id score
# 0  2    11
# 1  3    11
# 2  4    20
```