### PR TITLE
Update deps (numpy v2 and Python 3.13)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ keywords = ["padnas", "markdown", "table", "test", "development"]
 
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.13"
+python = ">=3.9,<3.14"
 pandas = "^2.1.1"
 numpy = "^2.0.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ keywords = ["padnas", "markdown", "table", "test", "development"]
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"
 pandas = "^2.1.1"
+numpy = "^2.0.0"
 
 
 [tool.poetry.group.dev.dependencies]
@@ -34,6 +35,4 @@ ignore = ["E501"]
 profile = "black"
 
 [tool.pytest.ini_options]
-pythonpath = [
-  "."
-]
+pythonpath = ["."]


### PR DESCRIPTION
- Use numpy v2 to get rid of the following warning when "make test".

```
============================================================================================== warnings summary ===============================================================================================
..\..\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\LocalCache\Local\pypoetry\Cache\virtualenvs\mdpd-IEhC06K2-py3.12\Lib\site-packages\dateutil\tz\tz.py:37
  C:\Users\ghiles.meddour\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\LocalCache\Local\pypoetry\Cache\virtualenvs\mdpd-IEhC06K2-py3.12\Lib\site-packages\dateutil\tz\tz.py:37: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    EPOCH = datetime.datetime.utcfromtimestamp(0)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

- Allow Python 3.13